### PR TITLE
removed netduino dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,3 @@
-# Vecc.Netduino.Drivers.Ili9341
+# Vecc.Netmf.Drivers.Ili9341
 Display driver for the .NET Micro Framework to drive the ILI9341 LCD screens.
+Forked and renamed/cleaned to work on netmf generically

--- a/README.md
+++ b/README.md
@@ -1,3 +1,3 @@
-# Vecc.Netmf.Drivers.Ili9341
+# Vecc.Netduino.Drivers.Ili9341
 Display driver for the .NET Micro Framework to drive the ILI9341 LCD screens.
-Forked and renamed/cleaned to work on netmf generically
+Forked and cleaned to work on netmf generically

--- a/src/Vecc.Netduino.Drivers.Ili9341/Driver.cs
+++ b/src/Vecc.Netduino.Drivers.Ili9341/Driver.cs
@@ -1,6 +1,7 @@
 using System.Threading;
 using Microsoft.SPOT.Hardware;
-using SecretLabs.NETMF.Hardware.Netduino;
+// using SecretLabs.NETMF.Hardware.Netduino; 
+//Poundy: changed to remove netduino dependencies
 
 namespace Vecc.Netduino.Drivers.Ili9341
 {
@@ -51,7 +52,7 @@ namespace Vecc.Netduino.Drivers.Ili9341
                                                  spiModule   // The used SPI bus (refers to a MOSI MISO and SCLK pin set)
                                                  ));
             _dataCommandPort = new OutputPort(dataCommandPin, false);
-            if (resetPin != Pins.GPIO_NONE)
+            if (resetPin != Cpu.Pin.GPIO_NONE)  //Poundy: changed to remove netduino dependencies
             {
                 _resetPort = new OutputPort(resetPin, false);
             }
@@ -59,7 +60,7 @@ namespace Vecc.Netduino.Drivers.Ili9341
             {
                 _resetPort = null;
             }
-            if (backlightPin != Pins.GPIO_NONE)
+            if (backlightPin != Cpu.Pin.GPIO_NONE) //Poundy: changed to remove netduino dependencies
             {
                 _backlightPort = new OutputPort(backlightPin, false);
             }

--- a/src/Vecc.Netduino.Drivers.Ili9341/Vecc.Netduino.Drivers.Ili9341.csproj
+++ b/src/Vecc.Netduino.Drivers.Ili9341/Vecc.Netduino.Drivers.Ili9341.csproj
@@ -53,7 +53,6 @@
   </ItemGroup>
   <ItemGroup>
     <Reference Include="Microsoft.SPOT.Hardware" />
-    <Reference Include="SecretLabs.NETMF.Hardware.Netduino, Version=4.3.1.0, Culture=neutral, processorArchitecture=MSIL" />
   </ItemGroup>
   <Import Condition="EXISTS('$(NetMfTargetsBaseDir)$(TargetFrameworkVersion)\CSharp.Targets')" Project="$(NetMfTargetsBaseDir)$(TargetFrameworkVersion)\CSharp.Targets" />
   <Import Condition="!EXISTS('$(NetMfTargetsBaseDir)$(TargetFrameworkVersion)\CSharp.Targets')" Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />


### PR DESCRIPTION
I've removed the Netduino dependencies in the library (not the sandpit program) so that it's more usable on other devices.

I wonder if you would also consider renaming the library and the folder of fonts, but that's obviously more work and somewhat unnecessary (but it does represent the real target)
